### PR TITLE
Fixed bug in hooks that caused page moving to throw an error

### DIFF
--- a/DidYouMean.hooks.php
+++ b/DidYouMean.hooks.php
@@ -108,7 +108,7 @@ class DidYouMeanHooks {
 		return true;
 	}
 	
-	public static function titleMoveComplete( &$title, &$nt, &$wgUser, &$pageid, &$redirid ) {
+	public static function titleMoveComplete( &$title, &$nt, &$wgUser, $pageid, $redirid ) {
 		$oldtitletext = $title->getText();
 		$oldns = $title->getNamespace();
 		$newtitletext = $nt->getText();


### PR DESCRIPTION
I ran into this issue in 1.25 specifically while trying to move a page it threw an error message. I'm not sure if newer versions are affected or not.